### PR TITLE
Refactor: Standardize CTA buttons site-wide

### DIFF
--- a/src/app/(marketing)/contact/page.tsx
+++ b/src/app/(marketing)/contact/page.tsx
@@ -48,16 +48,14 @@ export default function ContactPage() {
           title="Ready to Book Your Appointment?"
           description="Experience luxury beauty treatments at Vivi Aesthetics & Spa. Book your appointment today and discover why we're Calgary's premier destination for aesthetic treatments."
           primaryCTA={{
-            text: "Book Now",
+            text: "Book Your Appointment",
             href: "/pricing",
             icon: "calendar",
-            external: true,
           }}
           secondaryCTA={{
-            text: "Call Us",
-            href: "tel:+14037087654",
+            text: "See the current offers",
+            href: "/offers",
             variant: "outline",
-            icon: "phone",
           }}
           variant="gradient"
         />

--- a/src/app/(marketing)/offers/page.tsx
+++ b/src/app/(marketing)/offers/page.tsx
@@ -46,10 +46,9 @@ export default function OffersPage() {
             icon: "calendar",
           }}
           secondaryCTA={{
-            text: "Contact Us",
-            href: "/contact",
+            text: "See the current offers",
+            href: "/offers",
             variant: "outline",
-            icon: "phone",
           }}
         />
       </FadeIn>

--- a/src/app/(marketing)/services/page.tsx
+++ b/src/app/(marketing)/services/page.tsx
@@ -126,10 +126,9 @@ export default function ServicesPage() {
             href: "/pricing",
             variant: "default",
             icon: "calendar",
-            external: true,
           }}
           secondaryCTA={{
-            text: "View Offers",
+            text: "See the current offers",
             href: "/offers",
             variant: "outline",
           }}

--- a/src/components/blocks/shared-cta.tsx
+++ b/src/components/blocks/shared-cta.tsx
@@ -15,10 +15,10 @@ export function SharedCTA() {
         </p>
         <div className="mt-10 flex items-center justify-center gap-x-6">
           <Button asChild size="lg">
-            <Link href="/pricing">Book Appointment</Link>
+            <Link href="/pricing">Book Your Appointment</Link>
           </Button>
           <Button asChild variant="outline" size="lg">
-            <Link href="/contact">Contact Us</Link>
+            <Link href="/offers">See the current offers</Link>
           </Button>
         </div>
       </div>

--- a/src/data/home.ts
+++ b/src/data/home.ts
@@ -83,8 +83,8 @@ export const homePageData: HomePageData = {
       href: "/pricing",
     },
     secondaryCTA: {
-      text: "View Services",
-      href: "/services",
+      text: "See the current offers",
+      href: "/offers",
     },
     heroType: "video",
     backgroundImage: {
@@ -285,12 +285,12 @@ export const homePageData: HomePageData = {
     description:
       "Book your complimentary consultation today and discover how our personalized treatments can help you achieve your aesthetic goals.",
     primaryCTA: {
-      text: "Book Free Consultation",
-      href: "/contact",
+      text: "Book Your Appointment",
+      href: "/pricing",
     },
     secondaryCTA: {
-      text: "Call (403) 708-7654",
-      href: "tel:+14037087654",
+      text: "See the current offers",
+      href: "/offers",
     },
   },
 };


### PR DESCRIPTION
I've consolidated Call to Action (CTA) buttons to use consistent text and links across the website.

- Primary CTA is now uniformly 'Book Your Appointment' linking to '/pricing'.
- Secondary CTA is now uniformly 'See the current offers' linking to '/offers'.

I updated the following areas:
- `homePageData` in `src/data/home.ts` for homepage CTAs.
- The `SharedCTA` component in `src/components/blocks/shared-cta.tsx`.
- CTA configurations on `contact/page.tsx`, `offers/page.tsx`, and `services/page.tsx`.

This change removes duplicated CTA logic and ensures a consistent user experience for primary and secondary call-to-action prompts.