### PR TITLE
Fix: Remove overlapping call widget

### DIFF
--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,7 +1,6 @@
 import { Navbar } from "@/components/layout/navigation";
 import { Footer } from "@/components/layout";
 import { MarketingLayoutClient } from "@/components/layout/marketing-layout-client";
-import { CallButton } from "@/components/ui/call-button";
 
 export default function MarketingLayout({
   children,
@@ -13,7 +12,6 @@ export default function MarketingLayout({
       <Navbar />
       <MarketingLayoutClient>{children}</MarketingLayoutClient>
       <Footer />
-      <CallButton />
     </>
   );
 }


### PR DESCRIPTION
I removed the `CallButton` component from the marketing layout to eliminate the duplicate call widget. The `CallWidget` component, which includes the "Call Us" text, remains.